### PR TITLE
Populate Elasticsearch Fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ ES_NODES_PORT=9300
 KIBANA_PORT=5601
 ES_URL=https://elasticsearch
 MEM_LIMIT=1024m
-ES_HOST=localhost
+ES_HOST=elasticsearch
 ES_SCHEME=https
 ES_INDEX=bilara-data
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 
 populate_elastic:
 	@echo Populating Elasticsearch with data..
-	@python -c "from search.search import Search; Search()"
+	@$(COMPOSE) exec bilara-backend python -c "from search.search import Search; Search()"
 	@echo Elasticsearch has been populated!
 
 up:

--- a/backend/backend.dockerfile
+++ b/backend/backend.dockerfile
@@ -6,11 +6,13 @@ ENV PYTHONUNBUFFERED 1
 RUN pip install --upgrade pip && \
     pip install poetry
 
+RUN poetry config virtualenvs.create false
+
 # Copy poetry.lock* in case it doesn't exist in the repo
 COPY ./pyproject.toml ./poetry.lock* /app/
 
 WORKDIR /app/
-RUN /usr/local/bin/poetry install
+RUN poetry install --no-interaction --no-ansi --no-root
 
 RUN apt-get update && \
     apt-get install -y git && \


### PR DESCRIPTION
Change to `make populate_elastic` so that it creates an instance of the `Search` inside the container.
Depending on resources allocated to Docker, it might significantly increase the time to populate Elasticsearch.