### PR TITLE
Update nginx config to work with official image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,11 +211,10 @@ services:
       - ./logs/nginx/:/var/logs/nginx
       - ./frontend:/var/www/html
       - certs:/certs
-      - ./scripts/generate_nginx_certs.sh:/scripts/generate_nginx_certs.sh
+      - ./scripts/generate_nginx_certs.sh:/docker-entrypoint.d/generate_nginx_certs.sh
     ports:
       - 9080:80
       - ${DOCKER_BACKEND_PORT}:443
-    entrypoint: ["/bin/bash", "/scripts/generate_nginx_certs.sh"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /certs/key.pem && test -f /certs/cert.pem"]
       interval: 1s

--- a/scripts/generate_nginx_certs.sh
+++ b/scripts/generate_nginx_certs.sh
@@ -31,5 +31,3 @@ generate_cert() {
 
 generate_cert "/certs/localhost.key" "/certs/localhost.crt" "/CN=localhost"
 generate_cert "/certs/key.pem" "/certs/cert.pem" "/CN=localhost"
-
-exec /opt/bitnami/scripts/nginx/run.sh


### PR DESCRIPTION
As we are using the official nginx docker image, I needed to make these changes to get Bilara up and running.


Scripts that need to be run before nginx starts can now be placed in /docker-entrypoint.d/

I've moved the mount position of the `generate_nginx_certs.sh` script to reside there and removed the entrypoint in the compose script.

Take a look and see if this makes sense!